### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.23
+
+WORKDIR /usr/src/app
+
+# pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
+COPY src/go.mod src/go.sum ./
+RUN go mod download && go mod verify
+
+COPY src .
+RUN go build -v -o /usr/local/bin/app ./...
+
+CMD ["app"]

--- a/ShutDownDockerSwarm.bat
+++ b/ShutDownDockerSwarm.bat
@@ -1,0 +1,10 @@
+@echo off
+echo Shutting down docker swarm...
+echo[
+
+docker swarm leave --force
+
+echo[
+echo Docker swarm is shut down.
+echo[
+pause

--- a/StartDockerSwarm.bat
+++ b/StartDockerSwarm.bat
@@ -1,0 +1,15 @@
+@echo off
+:: Number of nodes that are launched.
+set NumberOfNodes=4
+
+echo Starting %NumberOfNodes% nodes...
+echo[
+
+docker swarm init
+docker build -t keykeeper .
+docker service create --name KeyKeeper-swarm --replicas %NumberOfNodes% -p 8080:8080 keykeeper
+
+echo[
+echo Check if the containers are running in Docker Desktop.
+echo[
+pause

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,5 +1,3 @@
 module KeyKeeper
 
 go 1.23
-
-require github.com/asynkron/protoactor-go v0.0.0-20240822202345-3c0e61ca19c9 // indirect

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,0 +1,5 @@
+module KeyKeeper
+
+go 1.23
+
+require github.com/asynkron/protoactor-go v0.0.0-20240822202345-3c0e61ca19c9 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,0 +1,2 @@
+github.com/asynkron/protoactor-go v0.0.0-20240822202345-3c0e61ca19c9 h1:mFWX0/oYqQ4Z+er0U56vA+ZPisr3kaYs1QsQetAVs6E=
+github.com/asynkron/protoactor-go v0.0.0-20240822202345-3c0e61ca19c9/go.mod h1:HTx47MGokOrouz8nrUmjyLLOVu+/kRNN6KKVG0XjQ3E=

--- a/src/main.go
+++ b/src/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	fmt.Println("Based Go execution frfr, no cap and stuff.")
+
+	// Pausing so that the docker container doesn't close right away.
+	// This won't be needed when the program has logic to continue to run.
+	time.Sleep(time.Duration(100) * time.Second)
+}


### PR DESCRIPTION
- Added support to allow Go code to be run in a docker container. 

This can be done by installing Docker Desktop, then running the Dockerfile while Docker Desktop is running. 

- Added a script to run a swarm of docker containers all running the same code.
- Added a script to shut down the swarm of containers.

