### PR TITLE
Added SQLite support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM golang:1.23
 
-WORKDIR /usr/src/app
+ENV CGO_ENABLED=1
+WORKDIR /usr/src/app/src
 
-# pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
 COPY src/go.mod src/go.sum ./
+COPY src/ ./
+COPY malware_hashes.db ../
 RUN go mod download && go mod verify
 
-COPY src .
 RUN go build -v -o /usr/local/bin/app ./...
 
 CMD ["app"]

--- a/src/database_handler.go
+++ b/src/database_handler.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	_ "github.com/mattn/go-sqlite3"
+	"log"
+	"os"
+)
+
+var db *sql.DB
+
+func init() {
+	dbPath := "../malware_hashes.db"
+
+	var err error
+
+	// Check that the database exists
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		log.Fatal("Database file doesn't exist: ", dbPath)
+	}
+
+	//Open SQLite database
+	db, err = sql.Open("sqlite3", dbPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = db.Ping()
+	if err != nil {
+		log.Fatal("Failed to connect to local sqlite database:", err)
+	} else {
+		fmt.Println("Successfully connected to local sqlite database.")
+	}
+}
+
+func checkHash(hash string) string {
+	var query string = `SELECT file_name, file_type_guess, signature, vtpercent, first_seen_utc, reporter
+	FROM malware_hashes
+	WHERE sha256_hash='` + hash + `';`
+
+	row, error := db.Query(query)
+	if error != nil {
+		fmt.Println(error)
+	}
+
+	defer row.Close()
+
+	var SQLResult string
+	for row.Next() {
+		var fileName string
+		var fileType string
+		var signature string
+		var vtpercent string
+		var firstSeen string
+		var reporter string
+		if error := row.Scan(&fileName, &fileType, &signature, &vtpercent, &firstSeen, &reporter); error != nil {
+			log.Fatal(error)
+		}
+
+		SQLResult = SQLResult + fmt.Sprintf("File Name: %s\nFile Type: %s\nSigning Authority: %s\nVirusTotal Percent: %s\nFirst Seen: %s\nReporter: %s\n",
+			fileName, fileType, signature, vtpercent, firstSeen, reporter)
+	}
+
+	return SQLResult
+}

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,3 +1,5 @@
 module KeyKeeper
 
 go 1.23
+
+require github.com/mattn/go-sqlite3 v1.14.24 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,2 +1,4 @@
 github.com/asynkron/protoactor-go v0.0.0-20240822202345-3c0e61ca19c9 h1:mFWX0/oYqQ4Z+er0U56vA+ZPisr3kaYs1QsQetAVs6E=
 github.com/asynkron/protoactor-go v0.0.0-20240822202345-3c0e61ca19c9/go.mod h1:HTx47MGokOrouz8nrUmjyLLOVu+/kRNN6KKVG0XjQ3E=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/src/main.go
+++ b/src/main.go
@@ -6,7 +6,11 @@ import (
 )
 
 func main() {
-	fmt.Println("Based Go execution frfr, no cap and stuff.")
+
+	var testHash string = `4c3f9505b832a5a8bb22d5d339b1dfd4800d96d3ffec4a495fdc2274efa6601c`
+	var hashResult = checkHash(testHash)
+
+	fmt.Println(hashResult)
 
 	// Pausing so that the docker container doesn't close right away.
 	// This won't be needed when the program has logic to continue to run.


### PR DESCRIPTION
This adds SQLite support and changes the Dockerfile to allow it to run. 

This change does require CGO_ENABLED=1 and a C compiler. I've included instructions below to add those, as you will need them to run this locally. It should work just fine with the Dockerfile.

To run the program locally with the SQLite library, Go needs to run with the ability to run C code. 
1: CGO_ENABLED=1 needs to be added to your IDE's environment variables. 
In GoLand, go to Run... -> Edit configurations... -> go build main.go -> Enter "CGO_ENABLED=1" into the "Environment" field.

2: Install tdm-gcc.
From this page download the 64+32-bit MinGw-w64 edition: https://jmeubank.github.io/tdm-gcc/articles/2021-05/10.3.0-release
Add the bin folder to your system's "path": Search for "environment variables" in windows -> Environment Variables -> System variables -> Path -> Edit... -> New -> C:\TDM-GCC-64\bin (Or wherever you installed TDM)